### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Access your calendars, contacts, and files via MCP!
 
+<a href="https://glama.ai/mcp/servers/@jahfer/dav-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jahfer/dav-mcp-server/badge" alt="DAV Server MCP server" />
+</a>
+
 ## Introduction
 
 This project is a Model Context Protocol (MCP) server that allows you to interact with your CalDAV, CardDAV, and WebDAV services. It supports both Fastmail and Apple iCloud accounts, configured via environment variables.


### PR DESCRIPTION
This PR adds a badge for the [DAV MCP Server](https://glama.ai/mcp/servers/@jahfer/dav-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jahfer/dav-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jahfer/dav-mcp-server/badge" alt="DAV Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.